### PR TITLE
TeamsTeam: Add 'Ensure' param to $PSBoundParameter

### DIFF
--- a/Modules/Office365DSC/DSCResources/MSFT_TeamsTeam/MSFT_TeamsTeam.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_TeamsTeam/MSFT_TeamsTeam.psm1
@@ -340,7 +340,8 @@ function Set-TargetResource
         -Platform MicrosoftTeams
 
     $team = Get-TargetResource @PSBoundParameters
-
+    
+    $PSBoundParameters.Add('Ensure',$Ensure)
     $CurrentParameters = $PSBoundParameters
     $CurrentParameters.Remove("GlobalAdminAccount")
     $CurrentParameters.Remove("Ensure")


### PR DESCRIPTION
#### Pull Request (PR) description
Modification ensures that 'Ensure' parameter is added to $PSBoundParameters and $ValuesToCheck, if not already set by the caller, because $PSBoundParameters does only contain parameters explicitly set by the caller, but no default values. 

#### This Pull Request (PR) fixes the following issues
- Fixes #372

